### PR TITLE
[WIP] INTERACT_CAULDRONフラグの実装

### DIFF
--- a/src/main/java/net/okocraft/moreflags/CustomFlags.java
+++ b/src/main/java/net/okocraft/moreflags/CustomFlags.java
@@ -34,6 +34,8 @@ public final class CustomFlags {
 
     public static final StateFlag EGG_SPAWN_CHICK = registerFlag(createStateFlag("egg-spawn-chick", true));
 
+    public static final StateFlag INTERACT_CAULDRON = registerFlag(createStateFlag("interact-cauldron", true));
+
     @SuppressWarnings("unchecked")
     private static <F extends Flag<?>, C extends F> F registerFlag(C flag) {
         FlagRegistry registry = WorldGuard.getInstance().getFlagRegistry();

--- a/src/main/java/net/okocraft/moreflags/Main.java
+++ b/src/main/java/net/okocraft/moreflags/Main.java
@@ -1,6 +1,7 @@
 package net.okocraft.moreflags;
 
 import net.okocraft.moreflags.listener.BeaconEffectListener;
+import net.okocraft.moreflags.listener.CauldronLevelChangeListener;
 import net.okocraft.moreflags.listener.DeathMessageListener;
 import net.okocraft.moreflags.listener.EggSpawnChickListener;
 import net.okocraft.moreflags.listener.RaidListener;
@@ -36,6 +37,7 @@ public class Main extends JavaPlugin {
         pm.registerEvents(new WorldGuardInternalListener(), this);
         pm.registerEvents(new RaidListener(this), this);
         pm.registerEvents(new EggSpawnChickListener(), this);
+        pm.registerEvents(new CauldronLevelChangeListener(), this);
         if (protocolLibHook != null) {
             protocolLibHook.registerHandlers();
         }

--- a/src/main/java/net/okocraft/moreflags/listener/CauldronLevelChangeListener.java
+++ b/src/main/java/net/okocraft/moreflags/listener/CauldronLevelChangeListener.java
@@ -1,0 +1,38 @@
+package net.okocraft.moreflags.listener;
+
+import com.sk89q.worldguard.LocalPlayer;
+import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import net.okocraft.moreflags.CustomFlags;
+import net.okocraft.moreflags.util.FlagUtil;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.CauldronLevelChangeEvent;
+
+public class CauldronLevelChangeListener implements Listener {
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    private void onCauldronLevelChange(CauldronLevelChangeEvent event) {
+        CauldronLevelChangeEvent.ChangeReason reason = event.getReason();
+        Entity entity = event.getEntity();
+
+        if (entity == null || entity.getType() != EntityType.PLAYER) return;
+        if (isNaturalInteract(reason)) return;
+
+        Block block = event.getBlock();
+        LocalPlayer player = WorldGuardPlugin.inst().wrapPlayer((Player) entity);
+        StateFlag.State state = FlagUtil.queryValue(block.getWorld(), block.getLocation(), player, CustomFlags.INTERACT_CAULDRON);
+        if (state == StateFlag.State.DENY) {
+            event.setCancelled(true);
+        }
+    }
+
+    private boolean isNaturalInteract(CauldronLevelChangeEvent.ChangeReason reason) {
+        return reason == CauldronLevelChangeEvent.ChangeReason.EXTINGUISH || reason == CauldronLevelChangeEvent.ChangeReason.EVAPORATE || reason == CauldronLevelChangeEvent.ChangeReason.NATURAL_FILL;
+    }
+}


### PR DESCRIPTION
### 概要
大釜に対してプレイヤー起因の操作を受け付けるかどうかのフラグを実装しました

### 懸念事項

WorldGuardでは大釜に対する操作は保護されるようになってしまっているため、 `config.yml` の `event-handling.interaction-whitelist` に大釜を追加する必要があります
参考: https://github.com/EngineHub/WorldGuard/commit/e4481f933723e53be5dbdb325601ee21f49bf209

### TODO

- [x] CauldronLevelChangeEvent
- [ ] PlayerBucketEmptyEvent
- [ ] PlayerBucketFillEvent