### PR TITLE
Add `sign-edit` Flag

### DIFF
--- a/src/main/java/net/okocraft/moreflags/CustomFlags.java
+++ b/src/main/java/net/okocraft/moreflags/CustomFlags.java
@@ -34,6 +34,8 @@ public final class CustomFlags {
 
     public static final StateFlag EGG_SPAWN_CHICK = registerFlag(createStateFlag("egg-spawn-chick", true));
 
+    public static final StateFlag SIGN_EDIT = registerFlag(createStateFlag("sign-edit", false));
+
     @SuppressWarnings("unchecked")
     private static <F extends Flag<?>, C extends F> F registerFlag(C flag) {
         FlagRegistry registry = WorldGuard.getInstance().getFlagRegistry();

--- a/src/main/java/net/okocraft/moreflags/Main.java
+++ b/src/main/java/net/okocraft/moreflags/Main.java
@@ -4,6 +4,7 @@ import net.okocraft.moreflags.listener.BeaconEffectListener;
 import net.okocraft.moreflags.listener.DeathMessageListener;
 import net.okocraft.moreflags.listener.EggSpawnChickListener;
 import net.okocraft.moreflags.listener.RaidListener;
+import net.okocraft.moreflags.listener.SignEditListener;
 import net.okocraft.moreflags.listener.VehicleMoveListener;
 import net.okocraft.moreflags.listener.WorldGuardInternalListener;
 import net.okocraft.moreflags.protocollib.ProtocolLibHook;
@@ -36,6 +37,7 @@ public class Main extends JavaPlugin {
         pm.registerEvents(new WorldGuardInternalListener(), this);
         pm.registerEvents(new RaidListener(this), this);
         pm.registerEvents(new EggSpawnChickListener(), this);
+        pm.registerEvents(new SignEditListener(), this);
         if (protocolLibHook != null) {
             protocolLibHook.registerHandlers();
         }

--- a/src/main/java/net/okocraft/moreflags/listener/SignEditListener.java
+++ b/src/main/java/net/okocraft/moreflags/listener/SignEditListener.java
@@ -1,0 +1,68 @@
+package net.okocraft.moreflags.listener;
+
+import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.bukkit.event.block.PlaceBlockEvent;
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import net.okocraft.moreflags.CustomFlags;
+import net.okocraft.moreflags.util.FlagUtil;
+import org.bukkit.event.Event;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.block.SignChangeEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class SignEditListener extends AbstractWorldGuardInternalListener {
+
+    @EventHandler(priority = EventPriority.LOW)
+    public void onChangeLow(@NotNull PlaceBlockEvent event) {
+        if (!(event.getOriginalEvent() instanceof SignChangeEvent signChangeEvent) ||
+                !getConfig().get(signChangeEvent.getBlock().getWorld().getName()).useRegions) {
+            return;
+        }
+
+        event.setSilent(true); // To prevent sending message from RegionProtectionListener
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onChangeHigh(@NotNull PlaceBlockEvent event) {
+        if (!(event.getOriginalEvent() instanceof SignChangeEvent signChangeEvent) ||
+                !getConfig().get(signChangeEvent.getBlock().getWorld().getName()).useRegions) {
+            return;
+        }
+
+        var player = signChangeEvent.getPlayer();
+        var localPlayer = getPlugin().wrapPlayer(player);
+
+        if (WorldGuard.getInstance().getPlatform().getSessionManager().hasBypass(localPlayer, localPlayer.getWorld())) {
+            return;
+        }
+
+        var block = signChangeEvent.getBlock();
+
+        var state = FlagUtil.queryValue(
+                block.getWorld(),
+                block.getLocation(),
+                getPlugin().wrapPlayer(player),
+                CustomFlags.SIGN_EDIT
+        );
+
+        if (event.getResult() == Event.Result.DENY && state == StateFlag.State.ALLOW) {
+            // Other flags cancel sign editing, but the sign-edit flag allows it.
+            event.setResult(Event.Result.ALLOW);
+            event.getBlocks().add(block); // Re-add the sign block
+        } else if (event.getResult() != Event.Result.DENY && state == StateFlag.State.DENY) {
+            // Other flags allow sign editing, but the sign-edit flag disallows it.
+            event.setResult(Event.Result.DENY);
+            event.getBlocks().remove(block); // Remove the sign block
+        } /* else {
+          // The sign-edit flag is not set, so we follow other flags such as "build" flag.
+        } */
+
+        event.setSilent(false);
+
+        if (event.getResult() == Event.Result.DENY) {
+            tellErrorMessage(player, block.getLocation(), TranslatableComponent.of("worldguard.error.denied.what.place-that-block"));
+        }
+    }
+}


### PR DESCRIPTION
## Description

Mojang added the feature that allows player editing the contents of the placed sign in Minecraft 1.20. In response to this feature, WorldGuard now checks whether a player who is trying to edit a sign can *build* in the region.

However, when the owner wants to allow non-members to edit the sign, it is not a good idea to allow them to *build*. Therefore, I added `sign-edit` flag to only allow editing of signs.

This flag is activated by setting to the region. In other words, this doesn't change the behavior unless it is explicitly set.

## Tests that I did in the game

1. Create the region by `/rg claim` and place the sign -> The non-members cannot edit the sign
2. Set `sign-edit` to `allow` -> All players can edit the sign
3. Set `sign-edit` to `deny` ->  All players cannot edit the sign
4. Set `sign-edit` to `allow` with `-g nonmembers` -> All players can edit the sign
5. Set `sign-edit` to `deny` with `-g members` ->  All players cannot edit the sign
6. Set `sign-edit` to `deny` with `-g nonowners` -> The members and the non-members cannot edit the sign
7. Unset `sign-edit` and set `build` to `allow` (or the sign is under the `global` region) -> All players can edit the sign
8. Set `build` to `allow` and set `sign-edit` to `deny` -> All players can place the sign, but cannot set the content of the sign

Perhaps there are other cases to check. I have checked the basic usage I assume.
