### PR TITLE
Folia

### DIFF
--- a/src/main/java/net/okocraft/moreflags/Main.java
+++ b/src/main/java/net/okocraft/moreflags/Main.java
@@ -3,11 +3,13 @@ package net.okocraft.moreflags;
 import net.okocraft.moreflags.listener.BeaconEffectListener;
 import net.okocraft.moreflags.listener.DeathMessageListener;
 import net.okocraft.moreflags.listener.EggSpawnChickListener;
+import net.okocraft.moreflags.listener.EnderPearlListener;
 import net.okocraft.moreflags.listener.RaidListener;
 import net.okocraft.moreflags.listener.SignEditListener;
 import net.okocraft.moreflags.listener.VehicleMoveListener;
 import net.okocraft.moreflags.listener.WorldGuardInternalListener;
 import net.okocraft.moreflags.protocollib.ProtocolLibHook;
+import net.okocraft.moreflags.util.PlatformHelper;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -38,6 +40,11 @@ public class Main extends JavaPlugin {
         pm.registerEvents(new RaidListener(this), this);
         pm.registerEvents(new EggSpawnChickListener(), this);
         pm.registerEvents(new SignEditListener(), this);
+
+        if (PlatformHelper.isFolia()) {
+            pm.registerEvents(new EnderPearlListener(), this);
+        }
+
         if (protocolLibHook != null) {
             protocolLibHook.registerHandlers();
         }

--- a/src/main/java/net/okocraft/moreflags/Main.java
+++ b/src/main/java/net/okocraft/moreflags/Main.java
@@ -33,7 +33,7 @@ public class Main extends JavaPlugin {
         PluginManager pm = getServer().getPluginManager();
         pm.registerEvents(new BeaconEffectListener(), this);
         pm.registerEvents(new DeathMessageListener(this), this);
-        pm.registerEvents(new VehicleMoveListener(this), this);
+        pm.registerEvents(new VehicleMoveListener(), this);
         pm.registerEvents(new WorldGuardInternalListener(), this);
         pm.registerEvents(new RaidListener(this), this);
         pm.registerEvents(new EggSpawnChickListener(), this);

--- a/src/main/java/net/okocraft/moreflags/listener/EnderPearlListener.java
+++ b/src/main/java/net/okocraft/moreflags/listener/EnderPearlListener.java
@@ -1,0 +1,45 @@
+package net.okocraft.moreflags.listener;
+
+import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.protection.flags.Flags;
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import net.okocraft.moreflags.util.FlagUtil;
+import org.bukkit.entity.EnderPearl;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.ProjectileHitEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class EnderPearlListener extends WorldGuardInternalListener {
+
+    @EventHandler
+    public void onHit(@NotNull ProjectileHitEvent event) {
+        if (!(event.getEntity() instanceof EnderPearl enderPearl) || !(enderPearl.getShooter() instanceof Player player)) {
+            return;
+        }
+
+        var localPlayer = getPlugin().wrapPlayer(player);
+
+        if (WorldGuard.getInstance().getPlatform().getSessionManager().hasBypass(localPlayer, localPlayer.getWorld())) {
+            return;
+        }
+
+        StateFlag.State state = FlagUtil.queryValue(
+                enderPearl.getWorld(),
+                enderPearl.getLocation(),
+                localPlayer,
+                Flags.ENDERPEARL
+        );
+
+        if (state == StateFlag.State.DENY) {
+            event.setCancelled(true);
+            enderPearl.remove();
+            AbstractWorldGuardInternalListener.tellErrorMessage(
+                    player,
+                    enderPearl.getLocation(),
+                    TranslatableComponent.of("worldguard.error.denied.what.use-that")
+            );
+        }
+    }
+}

--- a/src/main/java/net/okocraft/moreflags/util/PlatformHelper.java
+++ b/src/main/java/net/okocraft/moreflags/util/PlatformHelper.java
@@ -1,0 +1,70 @@
+package net.okocraft.moreflags.util;
+
+import net.okocraft.moreflags.Main;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Consumer;
+
+public final class PlatformHelper {
+
+    private static final boolean ENTITY_SCHEDULER;
+    private static final boolean FOLIA;
+
+    static {
+        boolean entityScheduler;
+
+        try {
+            Entity.class.getDeclaredMethod("getScheduler");
+            entityScheduler = true;
+        } catch (NoSuchMethodException ignored) {
+            entityScheduler = false;
+        }
+
+        ENTITY_SCHEDULER = entityScheduler;
+
+        boolean folia;
+
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            folia = true;
+        } catch (ClassNotFoundException e) {
+            folia = false;
+        }
+
+        FOLIA = folia;
+    }
+
+    public static boolean isFolia() {
+        return FOLIA;
+    }
+
+    public static <E extends Entity> void runEntityTask(@NotNull E entity, @NotNull Consumer<E> task, long delay) {
+        var runnable = toRunnable(entity, task);
+
+        if (ENTITY_SCHEDULER) {
+            entity.getScheduler().runDelayed(plugin(), $ -> runnable.run(), null, delay);
+        } else {
+            Bukkit.getScheduler().runTaskLater(plugin(), runnable, delay);
+        }
+    }
+
+    private static <E extends Entity> @NotNull Runnable toRunnable(@NotNull E entity, @NotNull Consumer<E> task) {
+        return () -> {
+            if (entity.isValid()) {
+                task.accept(entity);
+            }
+        };
+    }
+
+    private static @NotNull Plugin plugin() {
+        return JavaPlugin.getPlugin(Main.class);
+    }
+
+    private PlatformHelper() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/net/okocraft/moreflags/util/PlatformHelper.java
+++ b/src/main/java/net/okocraft/moreflags/util/PlatformHelper.java
@@ -1,13 +1,12 @@
 package net.okocraft.moreflags.util;
 
+import java.util.function.Consumer;
 import net.okocraft.moreflags.Main;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.function.Consumer;
 
 public final class PlatformHelper {
 
@@ -43,21 +42,15 @@ public final class PlatformHelper {
     }
 
     public static <E extends Entity> void runEntityTask(@NotNull E entity, @NotNull Consumer<E> task, long delay) {
-        var runnable = toRunnable(entity, task);
-
         if (ENTITY_SCHEDULER) {
-            entity.getScheduler().runDelayed(plugin(), $ -> runnable.run(), null, delay);
+            entity.getScheduler().runDelayed(plugin(), $ -> task.accept(entity), null, delay);
         } else {
-            Bukkit.getScheduler().runTaskLater(plugin(), runnable, delay);
+            Bukkit.getScheduler().runTaskLater(plugin(), () -> task.accept(entity), delay);
         }
     }
 
-    private static <E extends Entity> @NotNull Runnable toRunnable(@NotNull E entity, @NotNull Consumer<E> task) {
-        return () -> {
-            if (entity.isValid()) {
-                task.accept(entity);
-            }
-        };
+    public static boolean isOwnedByCurrentRegion(@NotNull Entity entity) {
+        return FOLIA ? Bukkit.isOwnedByCurrentRegion(entity) : Bukkit.isPrimaryThread();
     }
 
     private static @NotNull Plugin plugin() {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,3 +4,4 @@ main: net.okocraft.moreflags.Main
 api-version: 1.19
 depend: ["WorldGuard"]
 softdepend: ["ProtocolLib", "ToggleDeathMessage"]
+folia-supported: true


### PR DESCRIPTION
## TODOs

- [x] Change VehicleMoveListener implementation
- [ ] Test, test, test!
  - [ ] ~~Spigot???~~
  - [x] Paper
  - [x] Folia
  
### Problems of VehicleMoveListener

- Using `Bukkit#getScheduler` (L97)
- Using `Entity#teleport` (L95 and L98)

I don't know that this code can work on Folia only changing `getScheduler` to Folia schedulers and `teleport` to `teleportAsync`.

We probably need to check the current region of the vehicle and its passengers.

```java
            List<Entity> passengers = event.getVehicle().getPassengers();

            passengers.forEach(event.getVehicle()::removePassenger);
            event.getVehicle().teleport(event.getFrom());

            plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
                event.getVehicle().teleport(event.getFrom().clone().subtract(event.getTo().clone().subtract(event.getFrom())));
                passengers.forEach(event.getVehicle()::addPassenger);
            }, 3L);
```